### PR TITLE
Fix sharetime overflow at 1 second

### DIFF
--- a/Server.py
+++ b/Server.py
@@ -498,7 +498,7 @@ def handle(c):
                 except:
                     break
                 sharetime = resultreceived - jobsent # Time from start of hash computing to finding the result
-                sharetime = int(sharetime.microseconds / 1000) # Convert to ms
+                sharetime = sharetime.total_seconds() * 1000 # Get total ms
                 reward = int(int(sharetime) **2) / 750000000 # Calculate reward dependent on share submission time
                 try: # If client submitted hashrate, use it
                     hashrate = float(response[1])


### PR DESCRIPTION
The `.microseconds` counter overflows at 1000000, or after one second. This bug can cause AVR miners (which generally have share times over one second) to get smaller rewards than they should expect. It also throws off reporting in the `api.json`.

This PR fixes it by calculating the sharetime from the `.total_seconds()` method instead.